### PR TITLE
- fixed scroll reset behaviour when loading backlog

### DIFF
--- a/src/Room.qml
+++ b/src/Room.qml
@@ -8,8 +8,18 @@ Item {
     signal loadBacklog()
 
     function show(s) {
+        var oldContentY = flickable.contentY
+        var oldTextHeight = textArea.height
+        var wasAtEnd = flickable.atYEnd
         textArea.text = s
-        flickable.contentY = textArea.height - flickable.height
+        if(wasAtEnd) {
+            flickable.contentY = textArea.height - flickable.height
+        }
+        else
+        {
+            flickable.contentY = oldContentY + textArea.height - oldTextHeight
+        }
+
         if(textArea.height <= flickable.height) loadBacklog()
     }
     function clearInput() {


### PR DESCRIPTION
When loading a backlog the scroll position should now stay the same.
One thing to note is that the scroll position still changes when one is looking at history and a new message is appended at the end. I haven't come up with a solution to that yet.
