### PR TITLE
Fix messages ordering

### DIFF
--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -59,7 +59,7 @@ void MessageEventModel::changeRoom(QMatrixClient::Room* room)
     }
     else
     {
-        m_currentMessages = QList<QMatrixClient::Event*>();
+        m_currentMessages.clear();
     }
     endResetModel();
 }

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -47,19 +47,26 @@ void MessageEventModel::changeRoom(QMatrixClient::Room* room)
     beginResetModel();
     if( m_currentRoom )
     {
-        disconnect( m_currentRoom, &QMatrixClient::Room::newMessage, this, &MessageEventModel::newMessage );
+        m_currentRoom->disconnect(this);
     }
     m_currentRoom = room;
     if( room )
     {
-        m_currentMessages = room->messageEvents();
-        std::reverse(std::begin(m_currentMessages), std::end(m_currentMessages));
-        connect( room, &QMatrixClient::Room::newMessage, this, &MessageEventModel::newMessage );
+        using namespace QMatrixClient;
+        connect( room, &Room::aboutToAddNewMessages,
+                [=](const Events& events)
+                {
+                    beginInsertRows(QModelIndex(), 0, events.size() - 1);
+                });
+        connect( room, &Room::aboutToAddHistoricalMessages,
+                [=](const Events& events)
+                {
+                    beginInsertRows(QModelIndex(),
+                                    rowCount(), rowCount() + events.size() - 1);
+                });
+        connect( room, &Room::addedMessages,
+                 this, &MessageEventModel::endInsertRows );
         qDebug() << "connected" << room;
-    }
-    else
-    {
-        m_currentMessages = QList<QMatrixClient::Event*>();
     }
     endResetModel();
 }
@@ -85,17 +92,18 @@ void MessageEventModel::setConnection(QMatrixClient::Connection* connection)
 
 int MessageEventModel::rowCount(const QModelIndex& parent) const
 {
-    if( parent.isValid() )
+    if( !m_currentRoom || parent.isValid() )
         return 0;
-    return m_currentMessages.count();
+    return m_currentRoom->messageEvents().count();
 }
 
 QVariant MessageEventModel::data(const QModelIndex& index, int role) const
 {
-    if( index.row() < 0 || index.row() >= m_currentMessages.count() )
+    if( !m_currentRoom ||
+            index.row() < 0 || index.row() >= m_currentRoom->messageEvents().count() )
         return QVariant();
 
-    QMatrixClient::Event* event = m_currentMessages.at(index.row());
+    QMatrixClient::Event* event = *(m_currentRoom->messageEvents().end() - index.row() - 1);
 
     if( role == Qt::DisplayRole )
     {
@@ -211,26 +219,4 @@ QHash<int, QByteArray> MessageEventModel::roleNames() const
     roles[AuthorRole] = "author";
     roles[ContentRole] = "content";
     return roles;
-}
-
-void MessageEventModel::newMessage(QMatrixClient::Event* messageEvent)
-{
-    //qDebug() << "Message: " << message;
-    if( messageEvent->type() == QMatrixClient::EventType::Typing )
-    {
-        return;
-    }
-    for( int i = m_currentMessages.count() - 1; i >= 0; i-- )
-    {
-        if( messageEvent->timestamp() < m_currentMessages.at(i)->timestamp() )
-        {
-            beginInsertRows(QModelIndex(), i+1, i+1);
-            m_currentMessages.insert(i+1, messageEvent);
-            endInsertRows();
-            return;
-        }
-    }
-    beginInsertRows(QModelIndex(), 0, 0);
-    m_currentMessages.insert(0, messageEvent);
-    endInsertRows();
 }

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -21,10 +21,11 @@
 #include <QtCore/QAbstractListModel>
 #include <QtCore/QModelIndex>
 
+#include "events/event.h"
+
 namespace QMatrixClient
 {
     class Room;
-    class Event;
     class Connection;
 }
 
@@ -58,7 +59,7 @@ class MessageEventModel: public QAbstractListModel
     private:
         QMatrixClient::Connection* m_connection;
         QMatrixClient::Room* m_currentRoom;
-        QList<QMatrixClient::Event*> m_currentMessages;
+        QMatrixClient::Events m_currentMessages;
 };
 
 #endif // LOGMESSAGEMODEL_H

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -18,13 +18,14 @@
 #ifndef LOGMESSAGEMODEL_H
 #define LOGMESSAGEMODEL_H
 
+#include "events/event.h"
+
 #include <QtCore/QAbstractListModel>
 #include <QtCore/QModelIndex>
 
 namespace QMatrixClient
 {
     class Room;
-    class Event;
     class Connection;
 }
 
@@ -48,17 +49,13 @@ class MessageEventModel: public QAbstractListModel
 
         //override QModelIndex index(int row, int column, const QModelIndex& parent=QModelIndex()) const;
         //override QModelIndex parent(const QModelIndex& index) const;
-        int rowCount(const QModelIndex& parent) const override;
+        int rowCount(const QModelIndex& parent = QModelIndex()) const override;
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         QHash<int, QByteArray> roleNames() const override;
-
-    public slots:
-        void newMessage(QMatrixClient::Event* messageEvent);
 
     private:
         QMatrixClient::Connection* m_connection;
         QMatrixClient::Room* m_currentRoom;
-        QList<QMatrixClient::Event*> m_currentMessages;
 };
 
 #endif // LOGMESSAGEMODEL_H

--- a/client/models/roomlistmodel.h
+++ b/client/models/roomlistmodel.h
@@ -38,7 +38,7 @@ class RoomListModel: public QAbstractListModel
         Q_INVOKABLE QMatrixClient::Room* roomAt(int row);
 
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
-        int rowCount(const QModelIndex& parent=QModelIndex()) const override;
+        Q_INVOKABLE int rowCount(const QModelIndex& parent=QModelIndex()) const override;
 
     private slots:
         void namesChanged(QMatrixClient::Room* room);

--- a/client/qml/Tensor.qml
+++ b/client/qml/Tensor.qml
@@ -10,7 +10,6 @@ Rectangle {
     focus: true
     color: "#eee"
 
-    property var syncJob: null
     property bool initialised: false
 
     Connection { id: connection }
@@ -23,7 +22,7 @@ Rectangle {
             roomListItem.init()
             initialised = true
         }
-        syncJob = connection.sync(30000)
+        connection.sync(30000)
     }
 
     function login(user, pass, connect) {
@@ -37,7 +36,7 @@ Rectangle {
             connection.syncDone.connect(resync)
             connection.reconnected.connect(resync)
 
-            syncJob = connection.sync()
+            connection.sync()
         })
 
         var userParts = user.split(':')


### PR DESCRIPTION
This accompanies Fxrh/libqmatrixclient#30. One notable thing not directly related to ordering is that `MessageEventModel` now uses the messages container of `Room` instead of maintaining its own copy.
