### PR TITLE
Dont expose syncjob

### DIFF
--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -59,7 +59,7 @@ void MessageEventModel::changeRoom(QMatrixClient::Room* room)
     }
     else
     {
-        m_currentMessages = QList<QMatrixClient::Event*>();
+        m_currentMessages.clear();
     }
     endResetModel();
 }

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -21,10 +21,11 @@
 #include <QtCore/QAbstractListModel>
 #include <QtCore/QModelIndex>
 
+#include "events/event.h"
+
 namespace QMatrixClient
 {
     class Room;
-    class Event;
     class Connection;
 }
 
@@ -58,7 +59,7 @@ class MessageEventModel: public QAbstractListModel
     private:
         QMatrixClient::Connection* m_connection;
         QMatrixClient::Room* m_currentRoom;
-        QList<QMatrixClient::Event*> m_currentMessages;
+        QMatrixClient::Events m_currentMessages;
 };
 
 #endif // LOGMESSAGEMODEL_H

--- a/client/qml/Tensor.qml
+++ b/client/qml/Tensor.qml
@@ -10,7 +10,6 @@ Rectangle {
     focus: true
     color: "#eee"
 
-    property var syncJob: null
     property bool initialised: false
 
     Connection { id: connection }
@@ -23,7 +22,7 @@ Rectangle {
             roomListItem.init()
             initialised = true
         }
-        syncJob = connection.sync(30000)
+        connection.sync(30000)
     }
 
     function login(user, pass, connect) {
@@ -37,7 +36,7 @@ Rectangle {
             connection.syncDone.connect(resync)
             connection.reconnected.connect(resync)
 
-            syncJob = connection.sync()
+            connection.sync()
         })
 
         var userParts = user.split(':')


### PR DESCRIPTION
Fixes a problem with Tensor crashing on exit due to a double-deletion of a SyncJob object.
